### PR TITLE
refactor: streamline PR auto triage workflow by removing redundant title normalization checks

### DIFF
--- a/.github/workflows/pr-auto-triage.yml
+++ b/.github/workflows/pr-auto-triage.yml
@@ -123,25 +123,6 @@ jobs:
                 .replace(/\s+/g, " ");
             }
 
-            const branchSuffix = branch.includes("/") ? branch.split("/").pop() : branch;
-
-            const titleNorm = normalize(pr.title);
-            const branchNorm = normalize(branch);
-            const suffixNorm = normalize(branchSuffix);
-
-            core.info(`PR title: "${pr.title}"`);
-            core.info(`Branch: "${branch}"`);
-            core.info(`Normalized title: "${titleNorm}"`);
-            core.info(`Normalized branch: "${branchNorm}"`);
-            core.info(`Normalized suffix: "${suffixNorm}"`);
-
-            const isDefaultish = titleNorm === branchNorm || titleNorm === suffixNorm;
-
-            if (!isDefaultish) {
-              core.info("Title does not look auto-generated; not overwriting.");
-              return;
-            }
-
             // Extract issue number from branch
             const issueMatch = branch.match(/(?:^|\/)(\d+)(?:-|$)/);
             if (!issueMatch) {


### PR DESCRIPTION
## Suggested Title

<!-- Copy this format for your PR title. Include issue number if applicable. -->
<!-- Examples: "docs: format README and update development setup (#1)" or "feat: add font scaling preview" -->

**Format:** `[type]: [brief description] ([#issue])`

**Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `build`, `config`

---

## Description

<!-- Provide a brief description of what this PR does and why it's needed -->

Removes title gating for auto-set PR title workflow step. This ensures a consistent behavior by updating the title on PR open regardless of whether it was changed or not.

## Type of Change

<!-- Mark the relevant option(s) with an 'x'. Multiple types can be selected if applicable. -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/formatting changes (no functional changes)
- [x] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests (adding or updating tests)
- [x] 🔧 Build/config changes
- [ ] 🔒 Security fix

## Changes Made

<!-- List the main changes in this PR -->

- Removed gating for title auto-set step.
- Removed normalization checks.

## Checklist

<!-- Mark completed items with an 'x'. Only check items that are applicable to this PR. -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ] I have updated the documentation accordingly (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes (if applicable)
- [x] Any dependent changes have been merged and published
